### PR TITLE
Generate AWS test artifacts within the benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -45,7 +45,7 @@ jobs:
                 "type": "APPIUM_NODE",
                 "testPackageArn": "packages/benchmarking/MyTests.zip",
                 "testSpecArn": "packages/benchmarking/testSpec.yml"
-              },
+              }
             }
           artifact-types: ALL
 

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -44,7 +44,7 @@ jobs:
               "test": {
                 "type": "APPIUM_NODE",
                 "testPackageArn": "packages/benchmarking/MyTests.zip",
-                "testSpecArn": "packages/benchmarking/testSpec.yml"
+                "testSpecArn": "packages/benchmarking/testSpec.yaml"
               }
             }
           artifact-types: ALL

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -14,6 +14,17 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create Appium Test Zip
+        run: npm run bundle -w benchmarking-scripts
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -32,8 +43,8 @@ jobs:
               "devicePoolArn": "TestDevices",
               "test": {
                 "type": "APPIUM_NODE",
-                "testPackageArn": "MyTests.zip",
-                "testSpecArn": "testSpec.yml"
+                "testPackageArn": "packages/benchmarking/MyTests.zip",
+                "testSpecArn": "packages/benchmarking/testSpec.yml"
               },
             }
           artifact-types: ALL

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Schedule Device Farm Automated Test
         id: run-test
-        uses: aws-actions/aws-devicefarm-mobile-device-testing@v2.0
+        uses: aws-actions/aws-devicefarm-mobile-device-testing@v2.3
         with:
           run-settings-json: |
             {
@@ -35,7 +35,6 @@ jobs:
                 "testPackageArn": "MyTests.zip",
                 "testSpecArn": "testSpec.yml"
               },
-              "configuration": {}
             }
           artifact-types: ALL
 

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -40,7 +40,7 @@ jobs:
               "name": "GitHubAction-${{ github.workflow }}_${{ github.run_id }}_${{ github.run_attempt }}",
               "projectArn": "TestApp",
               "appArn": "benchmarkingTestApp.ipa",
-              "devicePoolArn": "TestDevices",
+              "devicePoolArn": "SmallDevicePool",
               "test": {
                 "type": "APPIUM_NODE",
                 "testPackageArn": "packages/benchmarking/MyTests.zip",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "babel-jest": "^29.6.3",
         "eslint": "^8.19.0",
         "jest": "^29.6.3",
+        "npm-bundle": "^3.0.3",
         "prettier": "2.8.8",
         "react-native-test-app": "^3.9.2",
         "react-test-renderer": "18.2.0",
@@ -10531,6 +10532,13 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/insync": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/insync/-/insync-2.1.1.tgz",
+      "integrity": "sha512-UzUhOZFpCMM22Xlig9iUPqalf8n7c4eYScamce1C+jN3ad8FtmVm42ryMwVq0hAxHbwUhWFhPvTFQQpFdDUKkw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/internal-slot": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
@@ -14623,6 +14631,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncp": "bin/ncp"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -14754,6 +14772,77 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-bundle": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/npm-bundle/-/npm-bundle-3.0.3.tgz",
+      "integrity": "sha512-fHF7FR32YNgjqi0MQMLnE78Ff9/wYd4/7/Cke3dLLi2QzETKotIiWGCxwDoXAZDWVoTuVRYQa2ZdiZPuBL7QnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^6.0.1",
+        "insync": "^2.1.1",
+        "mkdirp": "^0.5.1",
+        "ncp": "^2.0.0",
+        "rimraf": "^2.4.4"
+      },
+      "bin": {
+        "npm-bundle": "bin/cli.js"
+      }
+    },
+    "node_modules/npm-bundle/node_modules/glob": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm-bundle/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/npm-bundle/node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm-run-path": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-jest": "^29.6.3",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
+    "npm-bundle": "^3.0.3",
     "prettier": "2.8.8",
     "react-native-test-app": "^3.9.2",
     "react-test-renderer": "18.2.0",

--- a/packages/benchmarking/runTest.js
+++ b/packages/benchmarking/runTest.js
@@ -28,12 +28,10 @@ async function runTest(testId) {
     const benchmark = await driver.$(`~${testId}`);
     await benchmark.click();
 
-    const completed = await driver.$(`~${testIdCompleted}`);
+    const completed = await driver.$(`~${testId}Completed`);
 
     await completed.waitForDisplayed({ timeout: 20000 });
-  } catch (err) {
-    console.error(err);
-  } finally {
+
     const output = await driver.execute("mobile: stopPerfRecord", {
       profileName: "Time Profiler",
     });
@@ -43,7 +41,9 @@ async function runTest(testId) {
       if (err) throw err;
       console.log("Performance profile written to", perfTracePath);
     });
-
+  } catch (err) {
+    console.error(err);
+  } finally {
     await driver.deleteSession();
   }
 }


### PR DESCRIPTION
Resolves #17 

- Updates the aws device farm action
- Slightly refactors the test run to move the stopPerfRecord to the `try` block
- Generates the appium test zip on the fly in the benchmark
- Uses the latest version of the test run yaml from the github repo.
- Uses a test device pool with a single iPhone 15 Pro so that we don't use too many device farm minutes while testing