### PR TITLE
Remove scheduled benchmark run

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -7,8 +7,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: 0 * * * *
 
 jobs:
   benchmark:


### PR DESCRIPTION
We've collected a bunch of data here: https://rebeckerspecialties.github.io/benchmarking-test-app/dev/bench/. The benchmarks are fairly stable, within a reasonable margin of error.

The scheduled run can be removed once we've collected enough data.