### PR TITLE
Switch from Time Profiler to CPU Profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,9 @@ const runBenchmarkSuite = async () => {
 ```
 
 4. Follow the directions above to rebuild the app and rebundle the appium benchmark
+
+## Profiling with Xcode Instuments
+
+Currently, the `CPU Profiler` is being used to profile the app with Appium. This can be swapped out for other profilers by chaning out the `profileName` argument in the `startPerfRecord` command in `runBenchmarkWithProfiler`.
+
+A custom template can be used when profiling locally. For instance, if you want to profile CPU cache misses, you could create a `CPU Counter` template in XCode instruments and specify L1 cache misses in Instruments -> File -> Recording Options. For more details, see: https://www.advancedswift.com/counters-in-instruments/.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ appium driver doctor uiautomator2
 Run appium with the desired capabilities. the `udid` option can be omitted if using a simulator.
 
 ```
-appium --relaxed-security --default-capabilities \
+appium --relaxed-security --base-path=/wd/hub --default-capabilities \
   "{\"appium:deviceName\": \"<Your device name here>", \
   \"platformName\": \"iOS", \
   \"appium:app\": \"com.rbckr.TestApp", \

--- a/packages/benchmarking/runTest.ts
+++ b/packages/benchmarking/runTest.ts
@@ -31,7 +31,7 @@ async function runBenchmark(testId: string, driver: Browser) {
 async function runBenchmarkWithProfiler(testId: string, driver: Browser) {
   const perfTracePath = `${perfTraceDir}/${testId}-trace.zip`;
   await driver.execute("mobile: startPerfRecord", {
-    profileName: "Time Profiler",
+    profileName: "CPU Profiler",
     pid: "current",
     timeout: 2000,
   });
@@ -39,7 +39,7 @@ async function runBenchmarkWithProfiler(testId: string, driver: Browser) {
   await runBenchmark(testId, driver);
 
   const output = (await driver.execute("mobile: stopPerfRecord", {
-    profileName: "Time Profiler",
+    profileName: "CPU Profiler",
   })) as string;
 
   let buff = Buffer.from(output, "base64");


### PR DESCRIPTION
Resolves #19 

The CPU Profiler gives us better insight into what processes are taking up the most time on the CPU, and what the CPU usage is. 