### PR TITLE
Add missing dependencies for ir-engine

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,3 +28,9 @@ jobs:
 
       - name: Run benchmark parser tests
         run: npm test -w benchmark-parser
+
+      - name: Validate JavaScript build
+        run: |
+          cd apps/benchmarking-test-app
+          npm install
+          npm run build:ios:release

--- a/apps/benchmarking-test-app/package.json
+++ b/apps/benchmarking-test-app/package.json
@@ -26,7 +26,8 @@
     "react-native": "^0.75.0",
     "react-native-get-random-values": "^1.11.0",
     "react-native-permissions": "^3.10.1",
-    "three": "^0.167.1"
+    "three": "^0.167.1",
+    "ts-matches": "^5.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/benchmarking-test-app/package.json
+++ b/apps/benchmarking-test-app/package.json
@@ -20,6 +20,7 @@
     "@ir-engine/ecs": "^1.6.0",
     "@ir-engine/hyperflux": "^1.6.0",
     "bitecs": "^0.3.40",
+    "events": "^3.3.0",
     "node-cache": "^5.1.2",
     "node-schedule": "^2.1.1",
     "react": "18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@ir-engine/ecs": "^1.6.0",
         "@ir-engine/hyperflux": "^1.6.0",
         "bitecs": "^0.3.40",
+        "events": "^3.3.0",
         "node-cache": "^5.1.2",
         "node-schedule": "^2.1.1",
         "react": "18.2.0",
@@ -8261,7 +8262,8 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,8 @@
         "react-native": "^0.75.0",
         "react-native-get-random-values": "^1.11.0",
         "react-native-permissions": "^3.10.1",
-        "three": "^0.167.1"
+        "three": "^0.167.1",
+        "ts-matches": "^5.5.1"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -16410,6 +16411,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/ts-matches": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/ts-matches/-/ts-matches-5.5.1.tgz",
+      "integrity": "sha512-UFYaKgfqlg9FROK7bdpYqFwG1CJvP4kOJdjXuWoqxo9jCmANoDw1GxkSCpJgoTeIiSTaTH5Qr1klSspb8c+ydg=="
     },
     "node_modules/ts-toolbelt": {
       "version": "9.6.0",


### PR DESCRIPTION
The `ts-matches` and `events` dependencies need to be installed for the automated build to complete. The dependencies were installed locally when I ran npm install, but they were not included in the automated build, potentially due to different node versions. 

Benchmark run: https://github.com/rebeckerspecialties/benchmarking-test-app/actions/runs/10622999710