### PR TITLE
Fix: set profiling timeout to 500ms

### DIFF
--- a/packages/benchmarking/runTest.ts
+++ b/packages/benchmarking/runTest.ts
@@ -33,7 +33,7 @@ async function runBenchmarkWithProfiler(testId: string, driver: Browser) {
   await driver.execute("mobile: startPerfRecord", {
     profileName: "CPU Profiler",
     pid: "current",
-    timeout: 2000,
+    timeout: 30000,
   });
 
   await runBenchmark(testId, driver);

--- a/packages/benchmarking/runTest.ts
+++ b/packages/benchmarking/runTest.ts
@@ -33,7 +33,7 @@ async function runBenchmarkWithProfiler(testId: string, driver: Browser) {
   await driver.execute("mobile: startPerfRecord", {
     profileName: "CPU Profiler",
     pid: "current",
-    timeout: 30000,
+    timeout: 1000,
   });
 
   await runBenchmark(testId, driver);

--- a/packages/benchmarking/runTest.ts
+++ b/packages/benchmarking/runTest.ts
@@ -33,7 +33,7 @@ async function runBenchmarkWithProfiler(testId: string, driver: Browser) {
   await driver.execute("mobile: startPerfRecord", {
     profileName: "CPU Profiler",
     pid: "current",
-    timeout: 1000,
+    timeout: 500,
   });
 
   await runBenchmark(testId, driver);


### PR DESCRIPTION
Sets the xcode profiling to time out after more than 1 second. This means we get a smaller time window of data, but prevents the job from timing out completely.