### PR TITLE
Revert to Time Profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,6 @@ const runBenchmarkSuite = async () => {
 
 ## Profiling with Xcode Instuments
 
-Currently, the `CPU Profiler` is being used to profile the app with Appium. This can be swapped out for other profilers by chaning out the `profileName` argument in the `startPerfRecord` command in `runBenchmarkWithProfiler`.
+Currently, the `Time Profiler` is being used to profile the app with Appium. This can be swapped out for other profilers by chaning out the `profileName` argument in the `startPerfRecord` command in `runBenchmarkWithProfiler`.
 
 A custom template can be used when profiling locally. For instance, if you want to profile CPU cache misses, you could create a `CPU Counter` template in XCode instruments and specify L1 cache misses in Instruments -> File -> Recording Options. For more details, see: https://www.advancedswift.com/counters-in-instruments/.

--- a/packages/benchmarking/runTest.ts
+++ b/packages/benchmarking/runTest.ts
@@ -31,15 +31,15 @@ async function runBenchmark(testId: string, driver: Browser) {
 async function runBenchmarkWithProfiler(testId: string, driver: Browser) {
   const perfTracePath = `${perfTraceDir}/${testId}-trace.zip`;
   await driver.execute("mobile: startPerfRecord", {
-    profileName: "CPU Profiler",
+    profileName: "Time Profiler",
     pid: "current",
-    timeout: 500,
+    timeout: 2000,
   });
 
   await runBenchmark(testId, driver);
 
   const output = (await driver.execute("mobile: stopPerfRecord", {
-    profileName: "CPU Profiler",
+    profileName: "Time Profiler",
   })) as string;
 
   let buff = Buffer.from(output, "base64");


### PR DESCRIPTION
Reverts the on device profiling to Time Profiler, which has a reasonable amount of data for capture. Using CPU Profiler hangs the test run due to exporting too much data.