### PR TITLE
Track bundle size

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -117,6 +117,9 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     needs: build_ios_app
+    strategy:
+      matrix:
+        engine: [hermes, jsc]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -129,9 +132,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build benchmark parser
-        run: npm run build -w benchmark-parser
-
       - name: Create Appium Test Zip
         run: npm run bundle -w benchmarking-scripts
 
@@ -141,21 +141,21 @@ jobs:
           role-to-assume: ${{ secrets.DEVICE_FARM_IAM_ARN }}
           aws-region: us-west-2
 
-      - name: Download jsc artifact
+      - name: Download ${{matrix.engine}} artifact
         uses: actions/download-artifact@v4
         with:
-          name: jscApp
+          name: ${{matrix.engine}}App
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Benchmark with JavaScriptCore Engine
-        id: run-jsc-benchmark
+        id: run-benchmark
         uses: aws-actions/aws-devicefarm-mobile-device-testing@v2.3
         with:
           run-settings-json: |
             {
               "name": "GitHubAction-${{ github.workflow }}_${{ github.run_id }}_${{ github.run_attempt }}",
               "projectArn": "TestApp",
-              "appArn": "jscBenchmarking.ipa",
+              "appArn": "${{matrix.engine}}Benchmarking.ipa",
               "devicePoolArn": "SmallDevicePool",
               "executionConfiguration": {
                 "jobTimeoutMinutes": 20
@@ -171,41 +171,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: JSCOutputFiles
-          path: ${{ steps.run-jsc-benchmark.outputs.artifact-folder }}
-
-      - name: Download hermes artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: hermesApp
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run Benchmark with Hermes Engine
-        id: run-hermes-benchmark
-        uses: aws-actions/aws-devicefarm-mobile-device-testing@v2.3
-        with:
-          run-settings-json: |
-            {
-              "name": "GitHubAction-${{ github.workflow }}_${{ github.run_id }}_${{ github.run_attempt }}",
-              "projectArn": "TestApp",
-              "appArn": "hermesBenchmarking.ipa",
-              "devicePoolArn": "SmallDevicePool",
-              "executionConfiguration": {
-                "jobTimeoutMinutes": 20
-              },
-              "test": {
-                "type": "APPIUM_NODE",
-                "testPackageArn": "packages/benchmarking/MyTests.zip",
-                "testSpecArn": "packages/benchmarking/testSpec.yaml"
-              }
-            }
-          artifact-types: ALL
-
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: HermesOutputFiles
-          path: ${{ steps.run-hermes-benchmark.outputs.artifact-folder }}
+          name: ${{matrix.engine}}OutputFiles
+          path: ${{ steps.run-benchmark.outputs.artifact-folder }}
 
   parse-benchmarks:
     runs-on: ubuntu-latest
@@ -225,14 +192,14 @@ jobs:
       - name: Download JSC Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: "JSCOutputFiles"
+          name: "jscOutputFiles"
           path: "jscOutput"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Hermes Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: "HermesOutputFiles"
+          name: "hermesOutputFiles"
           path: "hermesOutput"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -174,10 +174,6 @@ jobs:
           name: JSCOutputFiles
           path: ${{ steps.run-jsc-benchmark.outputs.artifact-folder }}
 
-      - name: Extract JSC Artifacts
-        run: |
-          ./scripts/unzipArchive.sh ${{ steps.run-jsc-benchmark.outputs.artifact-folder }} benchmarks/jsc
-
       - name: Download hermes artifact
         uses: actions/download-artifact@v4
         with:
@@ -211,14 +207,45 @@ jobs:
           name: HermesOutputFiles
           path: ${{ steps.run-hermes-benchmark.outputs.artifact-folder }}
 
-      - name: Extract Hermes Artifacts
+  parse-benchmarks:
+    runs-on: ubuntu-latest
+    needs: benchmark
+    steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build benchmark parser
+        run: npm run build -w benchmark-parser
+
+      - name: Download JSC Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: "JSCOutputFiles"
+          path: "jscOutput"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Hermes Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: "HermesOutputFiles"
+          path: "hermesOutput"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract benchmark results from artifacts
         run: |
-          ./scripts/unzipArchive.sh ${{ steps.run-hermes-benchmark.outputs.artifact-folder }} benchmarks/hermes
+          ./scripts/unzipArchive.sh jscOutput benchmarks/jsc
+          ./scripts/unzipArchive.sh hermesOutput benchmarks/hermes
 
       - name: Download hermes bundle
         uses: actions/download-artifact@v4
         with:
           name: hermesBundle
+          path: bundleDist
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Parse Benchmarks

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -211,11 +211,17 @@ jobs:
           ./scripts/unzipArchive.sh jscOutput benchmarks/jsc
           ./scripts/unzipArchive.sh hermesOutput benchmarks/hermes
 
-      - name: Download hermes bundle
+      - name: Download javascript bundle
         uses: actions/download-artifact@v4
         with:
-          name: hermesBundle
+          name: jscBundle
           path: bundleDist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download executable artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: jscApp
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Parse Benchmarks

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -178,6 +178,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: benchmark
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -107,6 +107,13 @@ jobs:
           path: ${{ runner.temp }}/build/${{matrix.engine}}Benchmarking.ipa
           retention-days: 3
 
+      - name: Upload bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{matrix.engine}}Bundle
+          path: apps/benchmarking-test-app/dist/main.ios.jsbundle
+          retention-days: 3
+
   benchmark:
     runs-on: ubuntu-latest
     needs: build_ios_app
@@ -207,6 +214,12 @@ jobs:
       - name: Extract Hermes Artifacts
         run: |
           ./scripts/unzipArchive.sh ${{ steps.run-hermes-benchmark.outputs.artifact-folder }} benchmarks/hermes
+
+      - name: Download hermes bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: hermesBundle
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Parse Benchmarks
         run: npm run parse-benchmarks

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -105,14 +105,14 @@ jobs:
         with:
           name: ${{matrix.engine}}App
           path: ${{ runner.temp }}/build/${{matrix.engine}}Benchmarking.ipa
-          retention-days: 3
+          retention-days: 1
 
       - name: Upload bundle
         uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.engine}}Bundle
           path: apps/benchmarking-test-app/dist/main.ios.jsbundle
-          retention-days: 3
+          retention-days: 1
 
   benchmark:
     runs-on: ubuntu-latest

--- a/packages/benchmark-parser/src/index.ts
+++ b/packages/benchmark-parser/src/index.ts
@@ -4,5 +4,6 @@ import path from "path";
 const benchmarkPath = path.resolve(process.cwd(), "benchmarks");
 const outputPath = path.resolve(process.cwd(), "benchmark.json");
 const bundlePath = path.resolve(process.cwd(), "bundleDist/main.ios.jsbundle");
+const executablePath = path.resolve(process.cwd(), "jscBenchmarking.ipa");
 
-parseBenchmarks(benchmarkPath, bundlePath, outputPath);
+parseBenchmarks(benchmarkPath, bundlePath, executablePath, outputPath);

--- a/packages/benchmark-parser/src/index.ts
+++ b/packages/benchmark-parser/src/index.ts
@@ -3,6 +3,6 @@ import path from "path";
 
 const benchmarkPath = path.resolve(process.cwd(), "benchmarks");
 const outputPath = path.resolve(process.cwd(), "benchmark.json");
-const bundlePath = path.resolve(process.cwd(), "main.ios.jsbundle");
+const bundlePath = path.resolve(process.cwd(), "bundle/main.ios.jsbundle");
 
 parseBenchmarks(benchmarkPath, bundlePath, outputPath);

--- a/packages/benchmark-parser/src/index.ts
+++ b/packages/benchmark-parser/src/index.ts
@@ -3,5 +3,6 @@ import path from "path";
 
 const benchmarkPath = path.resolve(process.cwd(), "benchmarks");
 const outputPath = path.resolve(process.cwd(), "benchmark.json");
+const bundlePath = path.resolve(process.cwd(), "main.ios.jsbundle");
 
-parseBenchmarks(benchmarkPath, outputPath);
+parseBenchmarks(benchmarkPath, bundlePath, outputPath);

--- a/packages/benchmark-parser/src/index.ts
+++ b/packages/benchmark-parser/src/index.ts
@@ -3,6 +3,6 @@ import path from "path";
 
 const benchmarkPath = path.resolve(process.cwd(), "benchmarks");
 const outputPath = path.resolve(process.cwd(), "benchmark.json");
-const bundlePath = path.resolve(process.cwd(), "bundle/main.ios.jsbundle");
+const bundlePath = path.resolve(process.cwd(), "bundleDist/main.ios.jsbundle");
 
 parseBenchmarks(benchmarkPath, bundlePath, outputPath);

--- a/packages/benchmark-parser/src/parseBenchmark.spec.ts
+++ b/packages/benchmark-parser/src/parseBenchmark.spec.ts
@@ -35,13 +35,19 @@ describe("parseBenchmark", () => {
         "benchmark-ms.txt": "1234567",
       },
     });
-    await parseBenchmarks("benchmarks", "file.ios.bundle", "benchmark.json");
+    await parseBenchmarks(
+      "benchmarks",
+      "file.ios.bundle",
+      "benchmark.ipa",
+      "benchmark.json"
+    );
 
     const benchmarkResult = await readFile("benchmark.json", "utf-8");
 
     expect(JSON.parse(benchmarkResult)).toEqual([
       { name: "benchmark-ms.txt", value: 1234567, unit: "ms" },
       { name: "Bundle Size", value: 10000, unit: "kiB" },
+      { name: "Executable Size", value: 10000, unit: "kiB" },
     ]);
   });
 
@@ -54,7 +60,12 @@ describe("parseBenchmark", () => {
       },
     });
 
-    await parseBenchmarks("benchmarks", "file.ios.bundle", "benchmark.json");
+    await parseBenchmarks(
+      "benchmarks",
+      "file.ios.bundle",
+      "benchmark.ipa",
+      "benchmark.json"
+    );
 
     const benchmarkResult = await readFile("benchmark.json", "utf-8");
 
@@ -62,6 +73,7 @@ describe("parseBenchmark", () => {
       { name: "benchmark-ms.txt", value: 1234567, unit: "ms" },
       { name: "benchmark2-ms.txt", value: 2345678, unit: "ms" },
       { name: "Bundle Size", value: 10000, unit: "kiB" },
+      { name: "Executable Size", value: 10000, unit: "kiB" },
     ]);
   });
 
@@ -79,7 +91,12 @@ describe("parseBenchmark", () => {
       },
     });
 
-    await parseBenchmarks("benchmarks", "file.ios.bundle", "benchmark.json");
+    await parseBenchmarks(
+      "benchmarks",
+      "file.ios.bundle",
+      "benchmark.ipa",
+      "benchmark.json"
+    );
 
     const benchmarkResult = await readFile("benchmark.json", "utf-8");
 
@@ -104,7 +121,12 @@ describe("parseBenchmark", () => {
       },
     });
 
-    await parseBenchmarks("benchmarks", "file.ios.bundle", "benchmark.json");
+    await parseBenchmarks(
+      "benchmarks",
+      "file.ios.bundle",
+      "benchmark.ipa",
+      "benchmark.json"
+    );
 
     const benchmarkResult = await readFile("benchmark.json", "utf-8");
 

--- a/packages/benchmark-parser/src/parseBenchmark.spec.ts
+++ b/packages/benchmark-parser/src/parseBenchmark.spec.ts
@@ -1,9 +1,30 @@
 import mock from "mock-fs";
-import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 import { parseBenchmarks, parseBenchmarkType } from "./parseBenchmarks";
 import { readFile } from "fs/promises";
+import * as child_process from "child_process";
+
+const mockError = jest.spyOn(console, "error").mockImplementation(() => null);
+
+jest.mock("child_process");
+
+const mockExec = jest.spyOn(child_process, "exec");
 
 describe("parseBenchmark", () => {
+  beforeEach(() => {
+    mockExec.mockImplementation((_, _opts, callback) => {
+      callback?.(null, "10000 file.ios.bundle", "");
+      return {} as child_process.ChildProcess;
+    });
+  });
+
   afterEach(() => {
     mock.restore();
   });
@@ -14,12 +35,13 @@ describe("parseBenchmark", () => {
         "benchmark-ms.txt": "1234567",
       },
     });
-    await parseBenchmarks("benchmarks", "benchmark.json");
+    await parseBenchmarks("benchmarks", "file.ios.bundle", "benchmark.json");
 
     const benchmarkResult = await readFile("benchmark.json", "utf-8");
 
     expect(JSON.parse(benchmarkResult)).toEqual([
       { name: "benchmark-ms.txt", value: 1234567, unit: "ms" },
+      { name: "Bundle Size", value: 10000, unit: "kiB" },
     ]);
   });
 
@@ -32,7 +54,32 @@ describe("parseBenchmark", () => {
       },
     });
 
-    await parseBenchmarks("benchmarks", "benchmark.json");
+    await parseBenchmarks("benchmarks", "file.ios.bundle", "benchmark.json");
+
+    const benchmarkResult = await readFile("benchmark.json", "utf-8");
+
+    expect(JSON.parse(benchmarkResult)).toEqual([
+      { name: "benchmark-ms.txt", value: 1234567, unit: "ms" },
+      { name: "benchmark2-ms.txt", value: 2345678, unit: "ms" },
+      { name: "Bundle Size", value: 10000, unit: "kiB" },
+    ]);
+  });
+
+  it("should omit bundle size if exec throws", async () => {
+    const err = new Error("Failed to find file");
+    mockExec.mockImplementation((_, _opts, callback) => {
+      callback?.(err, "", "");
+      return {} as child_process.ChildProcess;
+    });
+    mock({
+      benchmarks: {
+        "benchmark-ms.txt": "1234567",
+        "benchmark2-ms.txt": "2345678",
+        "bad-benchmark.md": "2345678",
+      },
+    });
+
+    await parseBenchmarks("benchmarks", "file.ios.bundle", "benchmark.json");
 
     const benchmarkResult = await readFile("benchmark.json", "utf-8");
 
@@ -40,6 +87,35 @@ describe("parseBenchmark", () => {
       { name: "benchmark-ms.txt", value: 1234567, unit: "ms" },
       { name: "benchmark2-ms.txt", value: 2345678, unit: "ms" },
     ]);
+
+    expect(mockError).toHaveBeenCalledWith(err);
+  });
+
+  it("should omit bundle size if result cannot be parsed", async () => {
+    mockExec.mockImplementation((_, _opts, callback) => {
+      callback?.(null, "bad input", "");
+      return {} as child_process.ChildProcess;
+    });
+    mock({
+      benchmarks: {
+        "benchmark-ms.txt": "1234567",
+        "benchmark2-ms.txt": "2345678",
+        "bad-benchmark.md": "2345678",
+      },
+    });
+
+    await parseBenchmarks("benchmarks", "file.ios.bundle", "benchmark.json");
+
+    const benchmarkResult = await readFile("benchmark.json", "utf-8");
+
+    expect(JSON.parse(benchmarkResult)).toEqual([
+      { name: "benchmark-ms.txt", value: 1234567, unit: "ms" },
+      { name: "benchmark2-ms.txt", value: 2345678, unit: "ms" },
+    ]);
+
+    expect(mockError).toHaveBeenCalledWith(
+      new Error("Failed to parse file size from du result: bad input")
+    );
   });
 });
 


### PR DESCRIPTION
Resolve #44 

Tracks the JavaScript bundle size and JavaScriptCore executable size on the benchmark site: https://github.com/rebeckerspecialties/benchmarking-test-app/actions/runs/10929029309