### PR TITLE
Serialize Hermes and JSC runs

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -118,6 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_ios_app
     strategy:
+      max-parallel: 1
       matrix:
         engine: [hermes, jsc]
     steps:


### PR DESCRIPTION
Serializes Hermes and JSC runs to avoid overloading the max device count (5) when running in parallel. There are currently 6 devices required when running both benchmarks in parallel, so we have to wait for the first 5 devices to finish before running the last benchmark. This new configuration ends up taking the same amount of time to run, but avoids a costly token timeout on one of the benchmark runs.